### PR TITLE
fix toast hook subscription bug

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -179,7 +179,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- fix toast listener subscription to avoid repeated re-registration

## Testing
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af57a3b7888324a3c5766d3cbcfada