### PR TITLE
Remove yellow accents from site

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -3,7 +3,7 @@ const About = () => {
       <div className="container mx-auto px-6">
         <div className="grid lg:grid-cols-2 gap-8 items-center">
           <div className="animate-scale-in">
-            <div className="aspect-[4/5] bg-secondary rounded-sm overflow-hidden">
+            <div className="aspect-[4/5] bg-background rounded-sm overflow-hidden">
               <img src="/lovable-uploads/fe8d3bbf-a03b-480f-89ad-49ba8a761320.png" alt="Anna Verena, ceramic artist" className="w-full h-full object-cover" />
             </div>
           </div>

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -58,7 +58,7 @@ const Contact = () => {
       [e.target.name]: e.target.value
     }));
   };
-  return <section id="contact" className="py-16 bg-secondary/30">
+  return <section id="contact" className="py-16 bg-background">
       <div className="container mx-auto px-6">
         <div className="max-w-4xl mx-auto">
           <div className="text-center mb-12 animate-fade-in">

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,5 @@
 const Footer = () => {
-  return <footer className="bg-secondary py-12">
+  return <footer className="bg-background py-12">
       
     </footer>;
 };

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -30,7 +30,7 @@ const Gallery = () => {
     image: "/lovable-uploads/dab03e73-bd5a-4005-af83-6a134bae97de.png",
     description: "Handcrafted cups for daily rituals"
   }];
-  return <section id="gallery" className="py-12 bg-secondary/30">
+  return <section id="gallery" className="py-12 bg-background">
       <div className="container mx-auto px-6">
         <div className="text-center mb-8 animate-fade-in">
           <h2 className="font-crimson text-4xl lg:text-5xl font-semibold text-black mb-4">

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -25,7 +25,7 @@ const Hero = () => {
           </div>
           
           <div className="animate-scale-in">
-            <div className="aspect-square bg-secondary rounded-sm overflow-hidden">
+            <div className="aspect-square bg-background rounded-sm overflow-hidden">
               <img alt="Handcrafted pottery in a minimalist setting" className="w-full h-full object-cover hover:scale-105 transition-transform duration-700" src="/lovable-uploads/7b0e5e85-ce5e-44cb-aa1e-a85995a5d074.png" />
             </div>
           </div>

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -21,7 +21,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
             "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",
           error: "group-[.toaster]:bg-destructive group-[.toaster]:text-destructive-foreground group-[.toaster]:border-destructive",
           success: "group-[.toaster]:bg-primary group-[.toaster]:text-primary-foreground group-[.toaster]:border-primary",
-          warning: "group-[.toaster]:bg-yellow-400 group-[.toaster]:text-yellow-900 group-[.toaster]:border-yellow-400",
+          warning: "group-[.toaster]:bg-orange-400 group-[.toaster]:text-orange-900 group-[.toaster]:border-orange-400",
           info: "group-[.toaster]:bg-blue-400 group-[.toaster]:text-blue-900 group-[.toaster]:border-blue-400",
         },
       }}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,6 @@
 
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -124,5 +125,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- replace yellow backgrounds with neutral background color
- swap yellow toast warning styling for orange
- fix linting issues in utility components

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68af5ff60bbc8324b79ba108add13c6c